### PR TITLE
Send metrics to more than one Collectd server

### DIFF
--- a/example/1server.js
+++ b/example/1server.js
@@ -1,0 +1,11 @@
+var Collectd = require('../lib');
+
+var plugin = new Collectd(1000, "yourhost").plugin('collectd_out', 'test');
+
+setInterval(function() {
+    plugin.setGauge('users', 'fun', 42 + Math.sin(new Date().getTime() / 60000) * 23.5);
+    plugin.setGauge('load', '0', [1.0, 0.85, 0.7]);
+    plugin.addCounter('cpu', 'time', 1);
+    plugin.addCounter('if_octets', 'tap0', [3 * 1024 * 1024, (2 + Math.sin(new Date().getTime() / 60000) * 42) * 1024 * 1024]);
+}, 1000);
+

--- a/example/2servers.js
+++ b/example/2servers.js
@@ -1,0 +1,14 @@
+var Collectd = require('../lib');
+
+var plugin = new Collectd(1000, [
+	['host1'],
+	['host2', 25826]
+	]).plugin('collectd_out', 'test');
+
+setInterval(function() {
+    plugin.setGauge('users', 'fun', 42 + Math.sin(new Date().getTime() / 60000) * 23.5);
+    plugin.setGauge('load', '0', [1.0, 0.85, 0.7]);
+    plugin.addCounter('cpu', 'time', 1);
+    plugin.addCounter('if_octets', 'tap0', [3 * 1024 * 1024, (2 + Math.sin(new Date().getTime() / 60000) * 42) * 1024 * 1024]);
+}, 1000);
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,17 +89,54 @@ PluginInstance.prototype = {
 
 /**
  * Your context for a client periodically sending to 1 server. Use 
+ * 
+ * Syntax :
+ *   1/ var client = Collectd();
+ *   2/ var client = Collectd(int, string, int, string);
+ *   3/ var client = Collectd(int, object, ignored, string);
+ * 
+ * All arguments are optional (like in syntax 1)
+ * Syntax 1
+ *   no args (they are all optional)
+ * Syntax 2
+ *   arg1 is the interval between 2 sending data to Collectd servers
+ *   arg2 is the Collectd server name
+ *   arg3 is the Collectd server port
+ *   arg4 is the host name used in Collectd values
+ * Syntax 3
+ *   arg1 is the interval between 2 sending data to Collectd servers
+ *   arg2 is an array like this : [ ['host1', port], ['host2', port], ...]
+ *   arg3 is ignored.
+ *   arg4 is the host name used in Collectd values
  */
 function Collectd(interval, host, port, hostname) {
     this.interval = interval || 10000;
-    this.host = host || "ff18::efc0:4a42";
-    this.port = port || 25826;
+    this.serverHosts = [];
+
     this.plugins = {};
-	this.hostname = typeof hostname !== 'undefined' ? hostname : os.hostname();
-    this.sock = dgram.createSocket(net.isIPv6(this.host) ? 'udp6' : 'udp4');
-    this.sock.on('error', function(e) {
-	console.error(e.stack || e.message || e);
-    });
+    this.hostname = typeof hostname !== 'undefined' ? hostname : os.hostname();
+
+    /* Configure Collectd hosts to send metrics to */
+    switch(typeof(host)) {
+        case 'object':
+            for (var i=0; i < host.length; i++) {
+                var h = host[i];
+                this.serverHosts[this.serverHosts.length] = { 'host': h[0], 'port': (h[1] || 25826) };
+            }
+            break;
+        case 'string':
+            this.serverHosts = [{ 'host': host, 'port': (port || 25826) }];
+            break;
+        default:
+            this.serverHosts = [{ 'host': 'ff18::efc0:4a42', 'port': 25826 }];
+    }
+    /* Create the network sockets for each host */
+    for (var i=0; i < this.serverHosts.length; i++) {
+        this.serverHosts[i].sock = dgram.createSocket(net.isIPv6(this.serverHosts[i].host) ? 'udp6' : 'udp4');
+        this.serverHosts[i].sock.on('error', function(e) {
+                console.error(e.stack || e.message || e);
+        });
+    }
 
     setInterval(this.send.bind(this), this.interval);
 };
@@ -187,7 +224,9 @@ Collectd.prototype.send = function() {
 };
 
 Collectd.prototype.write = function(buf) {
-    this.sock.send(buf, 0, buf.length, this.port, this.host);
+    for (var i=0; i < this.serverHosts.length; i++) {
+        this.serverHosts[i].sock.send(buf, 0, buf.length, this.serverHosts[i].port, this.serverHosts[i].host);
+    }
 };
 
 


### PR DESCRIPTION
Hello,

Current Collectdout sends metrics to only one server.
If you want to send to more than one Collectd server, you can create 2 instances of Collectd. This is not the best way.

I send you this PR to configure the Collectd object to send to any number of Collectd servers you want.
Older syntax still works (for compatibility - I check the `typeof(arg 2)` )
New syntax is to have arg2 as an array of ['host', port] and arg3 is ignored.

Regards
